### PR TITLE
 🔧 add a new build phase to automatically increment build version if

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,12 @@ machine:
     OS: "11.1"
     GYM_CODE_SIGNING_IDENTITY: "iPhone Distribution: Red Hat, Inc."
 
+dependencies:
+  pre:
+    - /usr/libexec/PlistBuddy -c "Set :CFBundleVersion 1.$CIRCLE_BUILD_NUM" "secure-ios-app/Info.plist"
+    - /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString 1.$CIRCLE_BUILD_NUM" "secure-ios-app/Info.plist"
+    - echo "Set app version to $(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' 'secure-ios-app/Info.plist')"
+
 test:
   override:
     - set -o pipefail &&

--- a/secure-ios-app/Info.plist
+++ b/secure-ios-app/Info.plist
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
 the build is done in CircleCI

This is to make sure Krypowire will scan the new version of the app

ping @TommyJ1994 