### PR TITLE
FH-4790 - fix thread mis-syncing

### DIFF
--- a/secure-ios-app/services/StorageService.swift
+++ b/secure-ios-app/services/StorageService.swift
@@ -110,8 +110,8 @@ class RealmStorageService: StorageService {
                 let realm = try self.getRealmInstance()
                 try realm.safeWrite {
                     realm.add(note)
-                    
-                onComplete(nil, note.clone())
+                    try! realm.commitWrite()
+                    onComplete(nil, note.clone())
                 }
             } catch {
                 onComplete(error, nil)


### PR DESCRIPTION
### Description
When creating new notes, _sometimes_ (usually for the first couple of notes added) they don't appear in the listview immediately after creation because of slow writing to the database. The thread syncing therefore doesn't pick up the new changes. 

### Fix
Ensuring that the data is confirmed as committed to the database before syncing the threads will cause this not to happen.